### PR TITLE
fix(hospital): handle 401 errors in api calls

### DIFF
--- a/hospital/src/context/HospitalContext.jsx
+++ b/hospital/src/context/HospitalContext.jsx
@@ -47,6 +47,11 @@ const HospitalContextProvider = (props) => {
     } catch (error) {
       setDashData(false);
       toast.error(error.message);
+      if (error.response && error.response.status === 401) {
+        localStorage.removeItem('hToken');
+        setHToken('');
+        toast.error('Session expired. Please login again.');
+      }
     }
   };
 
@@ -63,6 +68,11 @@ const HospitalContextProvider = (props) => {
       }
     } catch (error) {
       toast.error(error.message);
+      if (error.response && error.response.status === 401) {
+        localStorage.removeItem('hToken');
+        setHToken('');
+        toast.error('Session expired. Please login again.');
+      }
     }
   };
 


### PR DESCRIPTION
Adds consistent 401 error handling to the `getDashData` and `cancelAppointment` functions in `HospitalContext`.

Previously, only the `getProfileData` function would handle a 401 error by clearing the user's session. If the token expired, other API calls would fail without logging the user out, leaving the UI in a broken state.

This change ensures that if any of these API calls receive a 401 Unauthorized response, the user's token is cleared from local storage and they are prompted to log in again.