### PR TITLE
Fix: Doctors not displaying in hospital panel

### DIFF
--- a/hospital/src/pages/Doctors.jsx
+++ b/hospital/src/pages/Doctors.jsx
@@ -9,9 +9,12 @@ const Doctors = () => {
 
   const fetchDoctors = async () => {
     try {
-      const { data } = await axios.get(backendUrl + '/api/hospital/doctors', {
-        headers: { hToken },
-      });
+      const { data } = await axios.get(
+        backendUrl + '/api/hospital/doctors',
+        {
+          headers: { Authorization: `Bearer ${hToken}` },
+        },
+      );
       if (data.success) {
         setDoctors(data.doctors);
       } else {


### PR DESCRIPTION
The doctors were not being displayed in the hospital panel because the API request to fetch the doctors was missing the correct authorization header. This commit fixes the issue by adding the 'Authorization: Bearer <token>' header to the request in `hospital/src/pages/Doctors.jsx`.