### PR TITLE
fix: Correct doctor model reference in hospital model

### DIFF
--- a/server/models/hospitalModel.js
+++ b/server/models/hospitalModel.js
@@ -136,7 +136,7 @@ const hospitalSchema = new mongoose.Schema({
   },
   doctors: [{
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'Doctor',
+    ref: 'doctor',
   }],
   createdAt: {
     type: Date,


### PR DESCRIPTION
The `doctors` field in `hospitalModel.js` was referencing 'Doctor' (capital 'D'), but the model was registered as 'doctor' (lowercase 'd'). This mismatch caused the `.populate('doctors')` call to fail, resulting in no doctors being displayed on the hospital panel.

This commit corrects the reference to 'doctor', resolving the issue.